### PR TITLE
feat(image-upload): Implement image upload functionality with validation

### DIFF
--- a/src/components/ImageUpload/ImagePreview.tsx
+++ b/src/components/ImageUpload/ImagePreview.tsx
@@ -1,0 +1,44 @@
+import Image from "next/image";
+import React, { useEffect, useState } from "react";
+
+interface ImagePreviewProps {
+  image: File;
+  onRemove: (imageName: string) => void;
+}
+
+const ImagePreview: React.FC<ImagePreviewProps> = ({ image, onRemove }) => {
+  const [previewUrl, setPreviewUrl] = useState<string>();
+
+  useEffect(() => {
+    const reader = new FileReader();
+    reader.onload = () => setPreviewUrl(reader.result as string);
+    reader.readAsDataURL(image);
+  }, [image]);
+
+  return (
+    <div className="relative p-1 border border-gray-300 rounded-md">
+      {previewUrl && (
+        <>
+          <Image
+            src={previewUrl}
+            width={80}
+            height={80}
+            alt={`Preview ${image.name}`}
+            objectFit="cover"
+            layout="fixed"
+          />
+          <button
+            onClick={() => onRemove(image.name)}
+            className="absolute top-0 right-0 bg-red-500 text-white rounded-full p-1"
+            style={{ transform: "translate(50%, -50%)" }}
+          >
+            ✕{" "}
+            {/* You can use an SVG icon or a different symbol here if you prefer */}
+          </button>
+        </>
+      )}
+    </div>
+  );
+};
+
+export default ImagePreview;

--- a/src/components/ImageUpload/ImageUpload.tsx
+++ b/src/components/ImageUpload/ImageUpload.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import React from "react";
+import { useImageUpload } from "./useImageUpload";
+import ImagePreview from "./ImagePreview";
+
+export const ImageUpload = () => {
+  const {
+    selectedImages,
+    handleSelectImages,
+    handleDragImages,
+    handleRemoveImage,
+    errors,
+  } = useImageUpload();
+
+  const onDrop = (event: React.DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    handleDragImages(event.dataTransfer.files);
+  };
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div
+        onDrop={onDrop}
+        onDragOver={(event) => event.preventDefault()}
+        className="border-2 border-dashed border-gray-300 rounded-lg p-6 text-center cursor-pointer"
+      >
+        Drag and drop images here, or click to select images
+        <input
+          type="file"
+          multiple
+          onChange={handleSelectImages}
+          accept="image/*"
+          className="hidden"
+          id="image-upload"
+        />
+        <label
+          htmlFor="image-upload"
+          className="ml-2 mt-2 text-blue-700 hover:text-blue-900 cursor-pointer"
+        >
+          <span>Select Images</span>
+        </label>
+      </div>
+      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
+        {selectedImages.map((image) => (
+          <ImagePreview
+            key={image.name}
+            image={image}
+            onRemove={handleRemoveImage}
+          />
+        ))}
+      </div>
+      {errors.map((error, index) => (
+        <div key={index} className="text-red-500" role="alert">
+          {error}
+        </div>
+      ))}
+    </div>
+  );
+};

--- a/src/components/ImageUpload/useImageUpload.ts
+++ b/src/components/ImageUpload/useImageUpload.ts
@@ -1,0 +1,71 @@
+import { imageFileSchema } from "@/lib/User/validations";
+import { useState } from "react";
+
+export const useImageUpload = () => {
+  const [selectedImages, setSelectedImages] = useState<File[]>([]);
+  const [errors, setErrors] = useState<string[]>([]);
+
+  const validateImage = (file: File): boolean => {
+    const validationResult = imageFileSchema.safeParse({
+      file: file,
+      size: file.size,
+      type: file.type,
+    });
+
+    if (validationResult.success) {
+      return true;
+    } else {
+      setErrors((prevErrors) => [
+        ...prevErrors,
+        ...validationResult.error.issues.map((issue) => issue.message),
+      ]);
+      return false;
+    }
+  };
+
+  // Add the resetErrors function to clear previous errors
+  const resetErrors = () => {
+    setErrors([]);
+  };
+
+  const handleSelectImages = (event: React.ChangeEvent<HTMLInputElement>) => {
+    resetErrors();
+    const files = event.target.files;
+    if (!files) return;
+
+    const newImages = Array.from(files).filter(validateImage);
+
+    setSelectedImages((currentImages) => [
+      ...currentImages,
+      ...newImages.filter(
+        (file) => !currentImages.map((f) => f.name).includes(file.name),
+      ),
+    ]);
+  };
+
+  const handleDragImages = (files: FileList) => {
+    resetErrors();
+    const newImages = Array.from(files).filter(validateImage);
+
+    setSelectedImages((currentImages) => [
+      ...currentImages,
+      ...newImages.filter(
+        (file) => !currentImages.map((f) => f.name).includes(file.name),
+      ),
+    ]);
+  };
+
+  const handleRemoveImage = (imageName: string) => {
+    setSelectedImages((currentImages) =>
+      currentImages.filter((image) => image.name !== imageName),
+    );
+  };
+
+  return {
+    selectedImages,
+    handleSelectImages,
+    handleDragImages,
+    handleRemoveImage,
+    errors,
+  };
+};

--- a/src/lib/User/validations.ts
+++ b/src/lib/User/validations.ts
@@ -9,6 +9,12 @@ export const SIGNUP_MAX_EMAIL_LENGTH = 200;
 export const SIGNUP_MAX_PASSWORD_LENGTH = 64;
 export const SIGNUP_MIN_PASSWORD_LENGTH = 8;
 export const SIGNUP_FULLNAME_REGEX = /^[a-zA-Z'-]+(?: [a-zA-Z'-]+)*$/;
+const MAX_FILE_SIZE = 5 * 1024 * 1024; // Max file size 5MB for each image
+const VALID_TYPES = ["image/jpeg", "image/png", "image/gif"];
+const IMAGE_ERROR_MESSAGES = {
+  type: "Unsupported file type. Please upload an image.",
+  size: "File is too large",
+};
 
 export const signUpFullNameValdator = z
   .string()
@@ -57,4 +63,18 @@ export const signUpSchema = z
 export const signInSchema = z.object({
   email: signUpEmailValidator,
   password: signUpPasswordValidator,
+});
+
+const fileTypeSchema = z.string().refine((type) => VALID_TYPES.includes(type), {
+  message: IMAGE_ERROR_MESSAGES.type,
+});
+
+const fileSizeSchema = z
+  .number()
+  .max(MAX_FILE_SIZE, { message: IMAGE_ERROR_MESSAGES.size });
+
+export const imageFileSchema = z.object({
+  file: z.instanceof(File),
+  size: fileSizeSchema,
+  type: fileTypeSchema,
 });


### PR DESCRIPTION
Add a new image upload component that allows users to select or drag and drop images into the application. Implement file type and size validations using Zod schemas to ensure that only valid image files (JPEG, PNG, GIF) under 5MB are accepted. Enhance user feedback by providing specific error messages for invalid files. Refine state management to handle multiple file selections and avoid duplicate entries. Ensure that the error state is reset before each new file processing to maintain accuracy in user notifications.

Include the useImageUpload hook to encapsulate the upload logic and state, making the component clean and easy to maintain. The hook provides functions to handle file selection, drag-and-drop operations, image validation, and the removal of selected images, as well as tracking and displaying error messages.

This commit lays the groundwork for robust and user-friendly image upload capabilities.